### PR TITLE
ci: add registry cleanup action

### DIFF
--- a/.github/workflows/cleanup-registry.yml
+++ b/.github/workflows/cleanup-registry.yml
@@ -1,0 +1,21 @@
+name: Clean up registry
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ghcr.io Cleanup Action
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.13
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: ${{ github.event.action != 'closed' }}
+          delete-untagged: true
+          delete-orphaned-images: true
+          delete-tags: ${{ github.head_ref }}

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Wiring details:
     ```
 3. Run the Docker container:
     ```bash
-    docker run --device /dev/gpiomem rpi-gpio-blinker
+    docker run --rm --device /dev/gpiochip4 rpi-gpio-blinker
     ```
+    >  *You might need to adjust the `--device` flag to match the GPIO chip on your Raspberry Pi. This example is designed for a Raspberry Pi 5*
 4. The LED should start blinking on your Raspberry Pi.
 
 ## License


### PR DESCRIPTION
- on closed PR remove branch images that were for testing purposes
- aims to keep only version tagged images